### PR TITLE
Patch Catalin for Magento EE FPC

### DIFF
--- a/app/code/community/Catalin/SEO/Helper/Data.php
+++ b/app/code/community/Catalin/SEO/Helper/Data.php
@@ -106,6 +106,8 @@ class Catalin_SEO_Helper_Data extends Mage_Core_Helper_Data
             }
         }
 
+        unset($layerParams['isLayerAjax']);
+
         // Sort by key - small SEO improvement
         ksort($layerParams);
         return $layerParams;

--- a/app/design/frontend/base/default/template/catalin_seo/catalog/product/list.phtml
+++ b/app/design/frontend/base/default/template/catalin_seo/catalog/product/list.phtml
@@ -173,6 +173,7 @@ foreach($_afterChildren as $_afterChildName):
     //<![CDATA[
     <?php if ($this->helper('catalin_seo')->isAjaxEnabled()): ?>
     CatalinSeoHandler.isAjaxEnabled = true;
+    CatalinSeoHandler.urlSuffix = <?php echo json_encode(Mage::getStoreConfig('catalog/seo/category_url_suffix')) ?>;
     <?php endif; ?>
     CatalinSeoHandler.bindListeners();
     //]]>

--- a/skin/frontend/base/default/js/catalin_seo/handler-ee-rwd.js
+++ b/skin/frontend/base/default/js/catalin_seo/handler-ee-rwd.js
@@ -1,4 +1,5 @@
 var CatalinSeoHandler = {
+    urlSuffix: null,
     listenersBinded: false,
     isAjaxEnabled: false,
     priceSlider: {
@@ -30,11 +31,22 @@ var CatalinSeoHandler = {
             url = $(el).getValue();
         }
 
-        // Add this to query string for full page caching systems
-        if (url.indexOf('?') != -1) {
-            fullUrl = url + '&isLayerAjax=1';
+        var suffix = CatalinSeoHandler.urlSuffix;
+        if (suffix !== null && url.substr(-suffix.length) == suffix) {
+            // Add to the query url so that FPC handles correctly.
+            var urlWithoutSuffix = url.substr(0, url.length - suffix.length);
+            if (urlWithoutSuffix.indexOf("/filter") == -1) {
+                fullUrl = urlWithoutSuffix + "/filter/isLayerAjax/1" + suffix;
+            } else {
+                fullUrl = urlWithoutSuffix + "/isLayerAjax/1" + suffix;
+            }
         } else {
-            fullUrl = url + '?isLayerAjax=1';
+            // Add this to query string for full page caching systems
+            if (url.indexOf('?') != -1) {
+                fullUrl = url + '&isLayerAjax=1';
+            } else {
+                fullUrl = url + '?isLayerAjax=1';
+            }
         }
 
         $('loading').show();


### PR DESCRIPTION
Currently Catalin will cause FPC on EE to expose page source on a category page.

![screen shot 2015-10-14 at 8 22 07 pm](https://cloud.githubusercontent.com/assets/3484527/10501597/4bc0562e-72b1-11e5-8884-231248a0975c.png)

Appends to the url, `?isLayerAjax=true` or `/isLayerAjax/1/`

### So either (a) catalin needs to not use FPC or (b) it needs to use a unique URL

This PR uses option (b) and simply uses a unique url to avoid FPC issue.