### PR TITLE
Correct FPC fix when using a blank suffix

### DIFF
--- a/app/code/community/Catalin/SEO/Helper/Data.php
+++ b/app/code/community/Catalin/SEO/Helper/Data.php
@@ -177,7 +177,7 @@ class Catalin_SEO_Helper_Data extends Mage_Core_Helper_Data
      * Checks for Enterprise and if it is, checks for the dot
      * before returning
      * @param  string $suffix
-     * @param  srting $urlParts
+     * @param  string $urlParts
      * @return string
      */
     public function getUrlBody($suffix, $urlParts) {

--- a/app/code/community/Catalin/SEO/etc/system.xml
+++ b/app/code/community/Catalin/SEO/etc/system.xml
@@ -74,7 +74,7 @@
                             </depends>
                         </multiple_choice_filters>
                         <routing_suffix translate="label">
-                            <label>Routing Souffix</label>
+                            <label>Routing Suffix</label>
                             <frontend_type>text</frontend_type>
                             <comment>Used in url generation (it should be alphanumeric) - Do not use slash ( / )</comment>
                             <backend_model>catalin_seo/system_config_backend_seo_catalog</backend_model>

--- a/app/design/frontend/base/default/template/catalin_seo/catalog/product/list.phtml
+++ b/app/design/frontend/base/default/template/catalin_seo/catalog/product/list.phtml
@@ -173,7 +173,7 @@ foreach($_afterChildren as $_afterChildName):
     //<![CDATA[
     <?php if ($this->helper('catalin_seo')->isAjaxEnabled()): ?>
     CatalinSeoHandler.isAjaxEnabled = true;
-    CatalinSeoHandler.urlSuffix = <?php echo json_encode(Mage::getStoreConfig('catalog/seo/category_url_suffix')) ?>;
+    CatalinSeoHandler.urlSuffix = <?php echo json_encode(Mage::helper('catalin_seo')->appendSuffix('', Mage::getStoreConfig('catalog/seo/category_url_suffix'))); ?>;
     CatalinSeoHandler.routingSuffix = <?php echo json_encode(Mage::helper('catalin_seo')->getRoutingSuffix()) ?>;
     <?php endif; ?>
     CatalinSeoHandler.bindListeners();

--- a/app/design/frontend/base/default/template/catalin_seo/catalog/product/list.phtml
+++ b/app/design/frontend/base/default/template/catalin_seo/catalog/product/list.phtml
@@ -174,6 +174,7 @@ foreach($_afterChildren as $_afterChildName):
     <?php if ($this->helper('catalin_seo')->isAjaxEnabled()): ?>
     CatalinSeoHandler.isAjaxEnabled = true;
     CatalinSeoHandler.urlSuffix = <?php echo json_encode(Mage::getStoreConfig('catalog/seo/category_url_suffix')) ?>;
+    CatalinSeoHandler.routingSuffix = <?php echo json_encode(Mage::helper('catalin_seo')->getRoutingSuffix()) ?>;
     <?php endif; ?>
     CatalinSeoHandler.bindListeners();
     //]]>

--- a/skin/frontend/base/default/js/catalin_seo/handler-ee-rwd.js
+++ b/skin/frontend/base/default/js/catalin_seo/handler-ee-rwd.js
@@ -35,8 +35,8 @@ var CatalinSeoHandler = {
         if (suffix !== null && (suffix.length === 0 || url.substr(-suffix.length) == suffix)) {
             // Add to the query url so that FPC handles correctly.
             var urlWithoutSuffix = url.substr(0, url.length - suffix.length);
-            if (urlWithoutSuffix.indexOf("/filter") == -1) {
-                fullUrl = urlWithoutSuffix + "/filter/isLayerAjax/1" + suffix;
+            if (urlWithoutSuffix.indexOf(CatalinSeoHandler.routingSuffix) == -1) {
+                fullUrl = urlWithoutSuffix + CatalinSeoHandler.routingSuffix + "/isLayerAjax/1" + suffix;
             } else {
                 fullUrl = urlWithoutSuffix + "/isLayerAjax/1" + suffix;
             }

--- a/skin/frontend/base/default/js/catalin_seo/handler-ee-rwd.js
+++ b/skin/frontend/base/default/js/catalin_seo/handler-ee-rwd.js
@@ -32,7 +32,7 @@ var CatalinSeoHandler = {
         }
 
         var suffix = CatalinSeoHandler.urlSuffix;
-        if (suffix !== null && url.substr(-suffix.length) == suffix) {
+        if (suffix !== null && (suffix.length === 0 || url.substr(-suffix.length) == suffix)) {
             // Add to the query url so that FPC handles correctly.
             var urlWithoutSuffix = url.substr(0, url.length - suffix.length);
             if (urlWithoutSuffix.indexOf("/filter") == -1) {


### PR DESCRIPTION
If the suffix is an empty string, `url.substr(-suffix.length)` will be the entire string, and therefore won't match.  The code works fine for an empty suffix, though.

It might be ideal if the controllers did not issue `$this->getResponse()->setHeader('Content-Type', 'application/json', true);` unless the URL without GET parameters included isLayerAjax.  Unfortunately, `Enterprise_PageCache_Model_Processor::_getFullPageUrl` uses fairly custom logic to determine this.

So it's currently possible to use this extension to "DoS" a site, even with this fix, by poisoning the cache headers for a request uri.