### PR TITLE
Calling getUrlKey, getUrlValue or getOptionId throws a warning.

### DIFF
--- a/app/code/community/Catalin/SEO/Model/Resource/Attribute/Urlkey.php
+++ b/app/code/community/Catalin/SEO/Model/Resource/Attribute/Urlkey.php
@@ -107,8 +107,8 @@ class Catalin_SEO_Model_Resource_Attribute_Urlkey extends Mage_Core_Model_Resour
             $data = $readAdapter->fetchAll($select);
 
             if (!empty($data)) {
-                self::$_cachedResults[$data['attribute_id']][$storeId] = $data;
-                self::$_cachedResults[$data['attribute_code']][$storeId] = $data;
+                self::$_cachedResults[$data[0]['attribute_id']][$storeId] = $data;
+                self::$_cachedResults[$data[0]['attribute_code']][$storeId] = $data;
             } else {
                 self::$_cachedResults[$whereValue][$storeId] = $data;
             }


### PR DESCRIPTION
The problem here is $data is not being handled as a multidimensional array:

```php
if (!empty($data)) {
    self::$_cachedResults[$data['attribute_id']][$storeId] = $data;
    self::$_cachedResults[$data['attribute_code']][$storeId] = $data;
} else {
    self::$_cachedResults[$whereValue][$storeId] = $data;
}
```

Both ```$data['attribute_id']``` and ```$data['attribute_code']``` will return null.