### PR TITLE
Re-enable configurable swatches

### DIFF
--- a/skin/frontend/base/default/js/catalin_seo/handler-ee-rwd.js
+++ b/skin/frontend/base/default/js/catalin_seo/handler-ee-rwd.js
@@ -52,6 +52,9 @@ var CatalinSeoHandler = {
                     self.toggleContent();
                     self.alignProductGridActions();
                     self.blockCollapsing();
+                    if (ConfigurableSwatchesList) {
+                        ConfigurableSwatchesList.init();
+                    }
                 } else {
                     $('ajax-errors').show();
                 }
@@ -187,6 +190,9 @@ var CatalinSeoHandler = {
                         self.toggleContent();
                         self.alignProductGridActions();
                         self.blockCollapsing();
+                        if (ConfigurableSwatchesList) {
+                            ConfigurableSwatchesList.init();
+                        }
                     }
                 });
             })(window.History);

--- a/skin/frontend/base/default/js/catalin_seo/handler.js
+++ b/skin/frontend/base/default/js/catalin_seo/handler.js
@@ -56,6 +56,9 @@ var CatalinSeoHandler = {
                     self.toggleContent();
                     self.alignProductGridActions();
                     self.blockCollapsing();
+                    if (ConfigurableSwatchesList) {
+                        ConfigurableSwatchesList.init();
+                    }
                 } else {
                     $('ajax-errors').show();
                 }
@@ -150,6 +153,9 @@ var CatalinSeoHandler = {
                         self.toggleContent();
                         self.alignProductGridActions();
                         self.blockCollapsing();
+                        if (ConfigurableSwatchesList) {
+                            ConfigurableSwatchesList.init();
+                        }
                     }
                 });
             })(window.History);


### PR DESCRIPTION
Currently, once the ajax completes, there is nothing to reinit the configurable swatch code. Add a call (with a safety check) to re-enable the default Mangento category swatch switcher.