### PR TITLE
Added check for ajax option enabled to avoid conflict with other ajax-aware modules

### DIFF
--- a/app/code/community/Catalin/SEO/controllers/CategoryController.php
+++ b/app/code/community/Catalin/SEO/controllers/CategoryController.php
@@ -43,7 +43,7 @@ class Catalin_Seo_CategoryController extends Mage_Catalog_CategoryController
             $update->addHandle($category->getLayoutUpdateHandle());
             $update->addHandle('CATEGORY_' . $category->getId());
             // apply custom ajax layout
-            if ($this->getRequest()->isAjax()) {
+            if (Mage::helper('catalin_seo')->isAjaxEnabled() && $this->getRequest()->isAjax()) {
                 $update->addHandle('catalog_category_layered_ajax_layer');
             }
             $this->loadLayoutUpdates();
@@ -72,7 +72,7 @@ class Catalin_Seo_CategoryController extends Mage_Catalog_CategoryController
             $this->_initLayoutMessages('checkout/session');
 
             // return json formatted response for ajax
-            if ($this->getRequest()->isAjax()) {
+            if (Mage::helper('catalin_seo')->isAjaxEnabled() && $this->getRequest()->isAjax()) {
                 
                 if(Mage::getEdition() == Mage::EDITION_ENTERPRISE){
                     $block = $this->getLayout()->getBlock('enterprisecatalog.leftnav');

--- a/app/code/community/Catalin/SEO/controllers/ResultController.php
+++ b/app/code/community/Catalin/SEO/controllers/ResultController.php
@@ -54,7 +54,7 @@ class Catalin_Seo_ResultController extends Mage_CatalogSearch_ResultController
 
             $this->loadLayout();
             // apply custom ajax layout
-            if ($this->getRequest()->isAjax()) {
+            if (Mage::helper('catalin_seo')->isAjaxEnabled() && $this->getRequest()->isAjax()) {
                 $update = $this->getLayout()->getUpdate();
                 $update->addHandle('catalog_category_layered_ajax_layer');
             }
@@ -62,7 +62,7 @@ class Catalin_Seo_ResultController extends Mage_CatalogSearch_ResultController
             $this->_initLayoutMessages('checkout/session');
 
             // return json formatted response for ajax
-            if ($this->getRequest()->isAjax()) {
+            if (Mage::helper('catalin_seo')->isAjaxEnabled() && $this->getRequest()->isAjax()) {
                 $listing = $this->getLayout()->getBlock('search_result_list')->toHtml();
 
 


### PR DESCRIPTION
If the ajax option is disabled, maybe because is installed another module that perform ajax requests to catalog/category/view url (eg. https://github.com/Strategery-Inc/Magento-InfiniteScroll, for lazy loading of products on scroll), the response should be the Magento standard one, and no additional layout handle should be added.