### PR TITLE
CE &EE handler.js swatch bug (resolves #26)

### DIFF
--- a/skin/frontend/base/default/js/catalin_seo/handler-ee-rwd.js
+++ b/skin/frontend/base/default/js/catalin_seo/handler-ee-rwd.js
@@ -52,8 +52,11 @@ var CatalinSeoHandler = {
                     self.toggleContent();
                     self.alignProductGridActions();
                     self.blockCollapsing();
+
                     if (ConfigurableSwatchesList) {
-                        ConfigurableSwatchesList.init();
+                        setTimeout(function(){
+                            $j(document).trigger('product-media-loaded');
+                        }, 0);
                     }
                 } else {
                     $('ajax-errors').show();
@@ -190,8 +193,11 @@ var CatalinSeoHandler = {
                         self.toggleContent();
                         self.alignProductGridActions();
                         self.blockCollapsing();
+
                         if (ConfigurableSwatchesList) {
-                            ConfigurableSwatchesList.init();
+                            setTimeout(function(){
+                                $j(document).trigger('product-media-loaded');
+                            }, 0);
                         }
                     }
                 });

--- a/skin/frontend/base/default/js/catalin_seo/handler.js
+++ b/skin/frontend/base/default/js/catalin_seo/handler.js
@@ -56,8 +56,11 @@ var CatalinSeoHandler = {
                     self.toggleContent();
                     self.alignProductGridActions();
                     self.blockCollapsing();
+
                     if (ConfigurableSwatchesList) {
-                        ConfigurableSwatchesList.init();
+                        setTimeout(function(){
+                            $j(document).trigger('product-media-loaded');
+                        }, 0);
                     }
                 } else {
                     $('ajax-errors').show();
@@ -153,8 +156,11 @@ var CatalinSeoHandler = {
                         self.toggleContent();
                         self.alignProductGridActions();
                         self.blockCollapsing();
+
                         if (ConfigurableSwatchesList) {
-                            ConfigurableSwatchesList.init();
+                            setTimeout(function(){
+                                $j(document).trigger('product-media-loaded');
+                            }, 0);
                         }
                     }
                 });


### PR DESCRIPTION
To reproduce: 

- In the CLP load a page with configurable swatches on _page 2_ of a multi-page paginated category list
- Switch to page 2
- Select the swatch below the product 

Expected: switch product image
Result: no Ajax call


Fix in this pull:

- The handler js for EE and CE called init() on the ConfigurableSwatches, instead we should call the $j document trigger which will do this for us
- There is a race condition when this is called because the page hasn't finished loading ajax content before the handler is recalled, then the items are replaced; effect is no click handlers for the sub-product swatch

This resolves #26.