### PR TITLE
Add nofollow option (configurable via admin)

### DIFF
--- a/app/code/community/Catalin/SEO/Helper/Data.php
+++ b/app/code/community/Catalin/SEO/Helper/Data.php
@@ -21,6 +21,7 @@ class Catalin_SEO_Helper_Data extends Mage_Core_Helper_Data
      */
 
     const MULTIPLE_FILTERS_DELIMITER = ',';
+    const REL_NOFOLLOW = 'rel="nofollow"';
 
     /**
      * Check if module is enabled or not
@@ -501,6 +502,13 @@ class Catalin_SEO_Helper_Data extends Mage_Core_Helper_Data
         }
 
         return "js/catalin_seo/handler.js";
+    }
+
+    public function getNofollow()
+    {
+        if(Mage::getStoreConfigFlag('catalin_seo/catalog/nofollow')){
+            return self::REL_NOFOLLOW;
+        }
     }
 
 }

--- a/app/code/community/Catalin/SEO/etc/config.xml
+++ b/app/code/community/Catalin/SEO/etc/config.xml
@@ -141,6 +141,7 @@
                 <price_slider>1</price_slider>
                 <multiple_choice_filters>1</multiple_choice_filters>
                 <routing_suffix>filter</routing_suffix>
+                <nofollow>0</nofollow>
             </catalog>
         </catalin_seo>
     </default>

--- a/app/code/community/Catalin/SEO/etc/system.xml
+++ b/app/code/community/Catalin/SEO/etc/system.xml
@@ -86,6 +86,15 @@
                                 <enabled>1</enabled>
                             </depends>
                         </routing_suffix>
+                        <nofollow translate="label">
+                            <label>Enable Nofollow on Layered Navigation Links</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>10</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </nofollow>
                     </fields>
                 </catalog>
             </groups>

--- a/app/design/frontend/base/default/template/catalin_seo/catalog/layer/filter.phtml
+++ b/app/design/frontend/base/default/template/catalin_seo/catalog/layer/filter.phtml
@@ -1,8 +1,11 @@
+<?php
+$_nofollow = Mage::helper('catalin_seo')->getNofollow();
+?>
 <ol>
     <?php foreach ($this->getItems() as $_item): ?>
         <li>
             <?php if ($_item->getCount() > 0): ?>
-                <a href="<?php echo ($_item->isSelected()) ? $_item->getRemoveUrl() : $_item->getUrl() ?>">
+                <a href="<?php echo ($_item->isSelected()) ? $_item->getRemoveUrl() : $_item->getUrl() ?>" <?php echo $_nofollow; ?> >
                     <input type="checkbox"<?php if ($_item->isSelected()): ?> checked="checked" <?php endif; ?>/>
                     <?php echo $_item->getLabel() ?>
                     <?php if ($this->shouldDisplayProductCount()): ?>

--- a/app/design/frontend/base/default/template/catalin_seo/catalog/layer/filter/swatches.phtml
+++ b/app/design/frontend/base/default/template/catalin_seo/catalog/layer/filter/swatches.phtml
@@ -5,6 +5,7 @@ $_swatchInnerWidth = $_dimHelper->getInnerWidth(Mage_ConfigurableSwatches_Helper
 $_swatchInnerHeight = $_dimHelper->getInnerHeight(Mage_ConfigurableSwatches_Helper_Swatchdimensions::AREA_LAYER);
 $_swatchOuterWidth = $_dimHelper->getOuterWidth(Mage_ConfigurableSwatches_Helper_Swatchdimensions::AREA_LAYER);
 $_swatchOuterHeight = $_dimHelper->getOuterHeight(Mage_ConfigurableSwatches_Helper_Swatchdimensions::AREA_LAYER);
+$_nofollow = Mage::helper('catalin_seo')->getNofollow();
 ?>
 
 <ol class="configurable-swatch-list">
@@ -20,7 +21,7 @@ $_swatchOuterHeight = $_dimHelper->getOuterHeight(Mage_ConfigurableSwatches_Help
         ?>
         <li<?php if ($_hasImage){ echo ' style="line-height: ' . $_lineHeight . 'px;"'; } ?>>
             <?php if ($_hasItems): ?>
-                <a href="<?php echo $this->urlEscape(($_item->isSelected()) ? $_item->getRemoveUrl() : $_item->getUrl()) ?>" class="<?php echo $_linkClass ?>">
+                <a href="<?php echo $this->urlEscape(($_item->isSelected()) ? $_item->getRemoveUrl() : $_item->getUrl()) ?>" class="<?php echo $_linkClass ?>" <?php echo $_nofollow; ?>>
             <?php else: ?>
                 <span class="<?php echo $_linkClass ?>">
             <?php endif; ?>


### PR DESCRIPTION
The latest Google Panda update had some sites being flagged for Catalin filter urls containing duplicate content.

This allows adding `rel=nofollow` to all filter urls (configurable via the admin)