### PR TITLE
Add option to customize loading icon

### DIFF
--- a/app/code/community/Catalin/SEO/Helper/Data.php
+++ b/app/code/community/Catalin/SEO/Helper/Data.php
@@ -83,6 +83,19 @@ class Catalin_SEO_Helper_Data extends Mage_Core_Helper_Data
     }
 
     /**
+     * Get the ID of the loading icon that will pop up while loading
+     *
+     * @return string
+     */
+    public function getLoadingIconId()
+    {
+        if (!$this->isEnabled()) {
+            return false;
+        }
+        return Mage::getStoreConfig('catalin_seo/catalog/loading_icon');
+    }
+
+    /**
      * Getter for layered navigation params
      * If $params are provided then it overrides the ones from registry
      *

--- a/app/code/community/Catalin/SEO/etc/config.xml
+++ b/app/code/community/Catalin/SEO/etc/config.xml
@@ -141,6 +141,7 @@
                 <price_slider>1</price_slider>
                 <multiple_choice_filters>1</multiple_choice_filters>
                 <routing_suffix>filter</routing_suffix>
+                <loading_icon>loading</loading_icon>
                 <nofollow>0</nofollow>
             </catalog>
         </catalin_seo>

--- a/app/code/community/Catalin/SEO/etc/system.xml
+++ b/app/code/community/Catalin/SEO/etc/system.xml
@@ -86,6 +86,19 @@
                                 <enabled>1</enabled>
                             </depends>
                         </routing_suffix>
+                        <loading_icon translate="label">
+                            <label>Loading Icon or Modal ID</label>
+                            <frontend_type>text</frontend_type>
+                            <comment>Enter an html ID that will show as the loading icon or modal.</comment>
+                            <backend_model>catalin_seo/system_config_backend_seo_catalog</backend_model>
+                            <sort_order>8</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <depends>
+                                <enabled>1</enabled>
+                            </depends>
+                        </loading_icon>
                         <nofollow translate="label">
                             <label>Enable Nofollow on Layered Navigation Links</label>
                             <frontend_type>select</frontend_type>

--- a/app/design/frontend/base/default/template/catalin_seo/catalog/product/list.phtml
+++ b/app/design/frontend/base/default/template/catalin_seo/catalog/product/list.phtml
@@ -173,8 +173,9 @@ foreach($_afterChildren as $_afterChildName):
     //<![CDATA[
     <?php if ($this->helper('catalin_seo')->isAjaxEnabled()): ?>
     CatalinSeoHandler.isAjaxEnabled = true;
-    CatalinSeoHandler.urlSuffix = <?php echo json_encode(Mage::helper('catalin_seo')->appendSuffix('', Mage::getStoreConfig('catalog/seo/category_url_suffix'))); ?>;
-    CatalinSeoHandler.routingSuffix = <?php echo json_encode(Mage::helper('catalin_seo')->getRoutingSuffix()) ?>;
+    CatalinSeoHandler.urlSuffix = <?php echo json_encode($this->helper('catalin_seo')->appendSuffix('', Mage::getStoreConfig('catalog/seo/category_url_suffix'))); ?>;
+    CatalinSeoHandler.routingSuffix = <?php echo json_encode($this->helper('catalin_seo')->getRoutingSuffix()) ?>;
+    CatalinSeoHandler.loadingIcon = $j('#<?php echo $this->helper('catalin_seo')->getLoadingIconId() ?>');
     <?php endif; ?>
     CatalinSeoHandler.bindListeners();
     //]]>

--- a/skin/frontend/base/default/js/catalin_seo/handler-ee-rwd.js
+++ b/skin/frontend/base/default/js/catalin_seo/handler-ee-rwd.js
@@ -33,7 +33,7 @@ var CatalinSeoHandler = {
 
         fullUrl = self.prepareAjaxUrl(url);
 
-        $('loading').show();
+        CatalinSeoHandler.loadingIcon.show();
         $('ajax-errors').hide();
 
         self.pushState(null, url, false);
@@ -61,7 +61,7 @@ var CatalinSeoHandler = {
                 } else {
                     $('ajax-errors').show();
                 }
-                $('loading').hide();
+                CatalinSeoHandler.loadingIcon.hide();
             }
         });
 


### PR DESCRIPTION
With project being customized with different look and feels, the loading icon should be able to
be customized as well. The option that gives the developer the most creative freedom is to design
their theme specific loader and have Catalin just show or hide it based on the id. The default
for the value is 'loader,' the icon bundled with Catalin.