### PR TITLE
Send a trigger once AJAX is complete

### DIFF
--- a/skin/frontend/base/default/js/catalin_seo/handler-ee-rwd.js
+++ b/skin/frontend/base/default/js/catalin_seo/handler-ee-rwd.js
@@ -62,12 +62,16 @@ var CatalinSeoHandler = {
                     $('ajax-errors').show();
                 }
                 $('loading').hide();
-            }
+            },
+            onComplete: CatalinSeoHandler.sendUpdateEvent
         });
 
         if (event) {
             event.preventDefault();
         }
+    },
+    sendUpdateEvent: function() {
+        $j(document).trigger('catalin:updatePage');
     },
     prepareAjaxUrl: function (url) {
         // In EE, the FPC caches response headers by request path, without query arguments.

--- a/skin/frontend/base/default/js/catalin_seo/handler.js
+++ b/skin/frontend/base/default/js/catalin_seo/handler.js
@@ -66,12 +66,16 @@ var CatalinSeoHandler = {
                     $('ajax-errors').show();
                 }
                 $('loading').hide();
-            }
+            },
+            onComplete: CatalinSeoHandler.sendUpdateEvent
         });
 
         if (event) {
             event.preventDefault();
         }
+    },
+    sendUpdateEvent: function() {
+        $j(document).trigger('catalin:updatePage');
     },
     pushState: function (data, link, replace) {
         var History = window.History;


### PR DESCRIPTION
There is often the need for custom js to be (re)implemented once AJAX has been completed.
Added in a trigger so that other functionality can hook into that event.