### PR TITLE
Config option for actual category link instead of filter + Show More link + translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@
 /app/etc/modules/Mage_*
 /app/etc/modules/Phoenix_*
 
-/app/locale/
 /app/Mage.php
 
 /app/code/core/

--- a/app/code/community/Catalin/SEO/Helper/Data.php
+++ b/app/code/community/Catalin/SEO/Helper/Data.php
@@ -141,9 +141,17 @@ class Catalin_SEO_Helper_Data extends Mage_Core_Helper_Data
         $url = Mage::getUrl('*/*/*', $params);
         $urlPath = '';
 
+        if(isset($filters['cat']) && Mage::getStoreConfigFlag('catalin_seo/catalog/category_links')) {
+            $urlParts = explode('/', $url);
+            $url = implode('/', array_merge($urlParts, array($filters['cat'])));
+        }
+
         if (!$noFilters) {
             // Add filters
             $layerParams = $this->getCurrentLayerParams($filters);
+            if(isset($layerParams['cat']) && Mage::getStoreConfigFlag('catalin_seo/catalog/category_links')) {
+                unset($layerParams['cat']);
+            }
             foreach ($layerParams as $key => $value) {
                 // Encode and replace escaped delimiter with the delimiter itself
                 $value = str_replace(urlencode(self::MULTIPLE_FILTERS_DELIMITER), self::MULTIPLE_FILTERS_DELIMITER, urlencode($value));

--- a/app/code/community/Catalin/SEO/Helper/Data.php
+++ b/app/code/community/Catalin/SEO/Helper/Data.php
@@ -519,4 +519,9 @@ class Catalin_SEO_Helper_Data extends Mage_Core_Helper_Data
         }
     }
 
+    public function getShowMore()
+    {
+        return Mage::getStoreConfig('catalin_seo/catalog/show_more_link');
+    }
+
 }

--- a/app/code/community/Catalin/SEO/etc/config.xml
+++ b/app/code/community/Catalin/SEO/etc/config.xml
@@ -109,6 +109,15 @@
         </index>
     </global>
     <frontend>
+        <translate>
+            <modules>
+                <catalin_seo>
+                    <files>
+                        <default>Catalin_SEO.csv</default>
+                    </files>
+                </catalin_seo>
+            </modules>
+        </translate>
         <routers>
             <catalog>
                 <args>

--- a/app/code/community/Catalin/SEO/etc/config.xml
+++ b/app/code/community/Catalin/SEO/etc/config.xml
@@ -142,7 +142,7 @@
                 <multiple_choice_filters>1</multiple_choice_filters>
                 <routing_suffix>filter</routing_suffix>
                 <nofollow>0</nofollow>
-		<category_links>0</category_links>
+                <show_more_link>0</show_more_link>
             </catalog>
         </catalin_seo>
     </default>

--- a/app/code/community/Catalin/SEO/etc/config.xml
+++ b/app/code/community/Catalin/SEO/etc/config.xml
@@ -142,6 +142,7 @@
                 <multiple_choice_filters>1</multiple_choice_filters>
                 <routing_suffix>filter</routing_suffix>
                 <nofollow>0</nofollow>
+		<category_links>0</category_links>
             </catalog>
         </catalin_seo>
     </default>

--- a/app/code/community/Catalin/SEO/etc/system.xml
+++ b/app/code/community/Catalin/SEO/etc/system.xml
@@ -104,6 +104,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </category_links>
+                        <show_more_link translate="label">
+                            <label>Use 'Show more' link</label>
+                            <comment>Show 'Show more' link when option has more than X items (use 0 for showing all)</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>10</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </show_more_link>
                     </fields>
                 </catalog>
             </groups>

--- a/app/code/community/Catalin/SEO/etc/system.xml
+++ b/app/code/community/Catalin/SEO/etc/system.xml
@@ -95,6 +95,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </nofollow>
+                        <category_links translate="label">
+                            <label>Category links go to category instead of applying filter</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>10</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </category_links>
                     </fields>
                 </catalog>
             </groups>

--- a/app/design/frontend/base/default/template/catalin_seo/catalog/layer/filter.phtml
+++ b/app/design/frontend/base/default/template/catalin_seo/catalog/layer/filter.phtml
@@ -24,6 +24,6 @@ $_showMore = Mage::helper('catalin_seo')->getShowMore();
         </li>
     <?php endforeach ?>
     <?php if($_showMore && count($this->getItems()) > $_showMore): ?>
-        <li><a href="#" class="show_more_filters" data-text-more="<?php echo Mage::helper('catalin_seo')->__('Show More'); ?>" data-text-less="<?php echo Mage::helper('catalin_seo')->__('Show Less'); ?>"><?php echo Mage::helper('catalin_seo')->__('Show More'); ?></a></li>
+        <li><a href="javascript:void()" class="show_more_filters" data-text-more="<?php echo Mage::helper('catalin_seo')->__('Show More'); ?>" data-text-less="<?php echo Mage::helper('catalin_seo')->__('Show Less'); ?>"><?php echo Mage::helper('catalin_seo')->__('Show More'); ?></a></li>
     <?php endif; ?>
 </ol>

--- a/app/design/frontend/base/default/template/catalin_seo/catalog/layer/filter.phtml
+++ b/app/design/frontend/base/default/template/catalin_seo/catalog/layer/filter.phtml
@@ -1,9 +1,10 @@
 <?php
 $_nofollow = Mage::helper('catalin_seo')->getNofollow();
+$_showMore = Mage::helper('catalin_seo')->getShowMore();
 ?>
 <ol>
-    <?php foreach ($this->getItems() as $_item): ?>
-        <li>
+    <?php foreach ($this->getItems() as $_key=>$_item): ?>
+        <li<?php if($_showMore && $_key > $_showMore): ?> class="filter_hide"<?php endif; ?>>
             <?php if ($_item->getCount() > 0): ?>
                 <a href="<?php echo ($_item->isSelected()) ? $_item->getRemoveUrl() : $_item->getUrl() ?>" <?php echo $_nofollow; ?> >
                     <input type="checkbox"<?php if ($_item->isSelected()): ?> checked="checked" <?php endif; ?>/>
@@ -22,4 +23,7 @@ $_nofollow = Mage::helper('catalin_seo')->getNofollow();
             <?php endif; ?>
         </li>
     <?php endforeach ?>
+    <?php if($_showMore && count($this->getItems()) > $_showMore): ?>
+        <li><a href="#" class="show_more_filters" data-text-more="<?php echo Mage::helper('catalin_seo')->__('Show More'); ?>" data-text-less="<?php echo Mage::helper('catalin_seo')->__('Show Less'); ?>"><?php echo Mage::helper('catalin_seo')->__('Show More'); ?></a></li>
+    <?php endif; ?>
 </ol>

--- a/app/locale/en_US/Catalin_SEO.csv
+++ b/app/locale/en_US/Catalin_SEO.csv
@@ -1,0 +1,7 @@
+"Update","Update"
+"Shop By","Shop By"
+"Price filter not available","Price filter not available"
+"Show More","Show More"
+"Show Less","Show Less"
+"Clear All","Clear All"
+"Filter","Filter"

--- a/app/locale/nl_NL/Catalin_SEO.csv
+++ b/app/locale/nl_NL/Catalin_SEO.csv
@@ -1,0 +1,7 @@
+"Update","Bijwerken"
+"Shop By","Filteren op"
+"Price filter not available","Prijs filter niet beschikbaar"
+"Show More","Toon meer"
+"Show Less","Toon minder"
+"Clear All","Verwijder alle filters"
+"Filter","Filter"

--- a/skin/frontend/base/default/css/catalin_seo/style.css
+++ b/skin/frontend/base/default/css/catalin_seo/style.css
@@ -19,3 +19,7 @@ div.price-slider .price-slider-to {
     cursor: w-resize;
     margin-top: -17px;
 }
+
+li.filter_hide { display:none; }
+
+a.show_more_filters { float:right; }

--- a/skin/frontend/base/default/js/catalin_seo/handler.js
+++ b/skin/frontend/base/default/js/catalin_seo/handler.js
@@ -1,3 +1,14 @@
+document.observe("dom:loaded", function () {
+    $j('a.show_more_filters').on('click', function (e) {
+        $j(e.target).parent().parent().find('.filter_hide').toggle();
+        if($j(e.target).text() == $j(e.target).data('text-more')) {
+            $j(e.target).text($j(e.target).data('text-less'));
+        } else {
+            $j(e.target).text($j(e.target).data('text-more'));
+        }
+    });
+});
+
 var CatalinSeoHandler = {
     listenersBinded: false,
     isAjaxEnabled: false,


### PR DESCRIPTION
Added config option that allows users to change the category filter link to the actual category instead of filtering the current category (Branch: master)