### PR TITLE
Move Catalin away from the default config section

### DIFF
--- a/app/code/community/Catalin/SEO/etc/system.xml
+++ b/app/code/community/Catalin/SEO/etc/system.xml
@@ -11,7 +11,7 @@
             <label>Catalin SEO</label>
             <tab>catalin</tab>
             <frontend_type>text</frontend_type>
-            <sort_order>1</sort_order>
+            <sort_order>1000</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
             <show_in_store>1</show_in_store>


### PR DESCRIPTION
Magento selects the lowest numbered section, but unfortunately this doesn't match the visual experience of "General" being first.