### PR TITLE
Replace block-layered-nav on ajax, instead of nesting

### DIFF
--- a/skin/frontend/base/default/js/catalin_seo/handler-ee-rwd.js
+++ b/skin/frontend/base/default/js/catalin_seo/handler-ee-rwd.js
@@ -43,7 +43,7 @@ var CatalinSeoHandler = {
             onSuccess: function (transport) {
                 if (transport.responseJSON) {
                     $('catalog-listing').update(transport.responseJSON.listing);
-                    $$('.block-layered-nav')[0].update(transport.responseJSON.layer);
+                    $$('.block-layered-nav')[0].replace(transport.responseJSON.layer);
                     self.pushState({
                         listing: transport.responseJSON.listing,
                         layer: transport.responseJSON.layer
@@ -180,7 +180,7 @@ var CatalinSeoHandler = {
 
                 self.pushState({
                     listing: $('catalog-listing').innerHTML,
-                    layer: $$('.block-layered-nav')[0].innerHTML
+                    layer: $$('.block-layered-nav')[0].outerHTML
                 }, document.location.href, true);
 
                 // Bind to StateChange Event
@@ -188,7 +188,7 @@ var CatalinSeoHandler = {
                     if (event.type == 'popstate') {
                         var State = History.getState();
                         $('catalog-listing').update(State.data.listing);
-                        $$('.block-layered-nav')[0].update(State.data.layer);
+                        $$('.block-layered-nav')[0].replace(State.data.layer);
                         self.ajaxListener();
                         self.toggleContent();
                         self.alignProductGridActions();


### PR DESCRIPTION
Before, ajax would cause a block-layered-nav to get nested inside a block-layered-nav.  Using replace and outerHTML makes it so we can work with existing templates that lack id="layered-navigation".

Note that in the CE version, it uses a parent id="layered-navigation", and updates its child content.  This parent is not present in EE as current.