### PR TITLE
added rel tags for next, prev, and canonical url

### DIFF
--- a/app/code/community/Catalin/SEO/Block/Catalog/Product/List/Pager.php
+++ b/app/code/community/Catalin/SEO/Block/Catalog/Product/List/Pager.php
@@ -37,4 +37,9 @@ class Catalin_SEO_Block_Catalog_Product_List_Pager extends Mage_Page_Block_Html_
         return $this->helper('catalin_seo')->getPagerUrl($params);
     }
 
+    public function getCurrentPageUrl()
+    {
+        return $this->getPageUrl($this->getCollection()->getCurPage());
+    }
+
 }

--- a/app/design/frontend/base/default/layout/catalin_seo.xml
+++ b/app/design/frontend/base/default/layout/catalin_seo.xml
@@ -14,6 +14,8 @@
                 <type>skin_js</type>
                 <name helper="catalin_seo/getSkinJsUrl"/>
             </action>
+	    <block type="page/html_pager" name="rel_next_prev_canonical" template="catalin_seo/catalog/rel_next_prev_canonical.phtml"/>
+	    
         </reference>
         <reference name="product_list_toolbar">
             <block type="catalin_seo/catalog_product_list_pager" name="product_list_toolbar_pager"/>

--- a/app/design/frontend/base/default/template/catalin_seo/catalog/rel_next_prev_canonical.phtml
+++ b/app/design/frontend/base/default/template/catalin_seo/catalog/rel_next_prev_canonical.phtml
@@ -1,0 +1,45 @@
+<?php
+
+$actionName = $this->getAction()->getFullActionName();
+if ($actionName == 'catalog_category_view') // Category Page
+{
+    $category = Mage::registry('current_category');
+
+    $prodCol = Mage::getSingleton('catalog/layer')->getProductCollection();
+    $tool = $this->getLayout()->createBlock('catalin_seo/catalog_product_list_pager')->setCollection($prodCol);
+
+    $linkPrev = false;
+    $linkNext = false;
+
+    if ($tool->getCollection()->getSelectCountSql()) {
+        if ($tool->getLastPageNum() > 1) {
+            if (!$tool->isFirstPage()) {
+                $linkPrev = true;
+                if ($tool->getCurrentPage() == 2) {
+                    $url = explode('?', $tool->getPreviousPageUrl());
+                    $prevUrl = @$url[0];
+                }
+                else {
+                    $prevUrl = $tool->getPreviousPageUrl();
+                }
+            }
+            if (!$tool->isLastPage()) {
+                $linkNext = true;
+                $nextUrl = $tool->getNextPageUrl();
+            }
+
+        }
+    }
+    if ($tool->getCurrentPage() == 1) {
+        $url = explode('?', $tool->getCurrentPageUrl());
+        $currentUrl = @$url[0];
+    } else {
+        $currentUrl = $tool->getCurrentPageUrl();
+    }
+    echo '<link rel="canonical" href="' . $currentUrl . '" />';
+
+    if ($linkPrev) echo '<link rel="prev" href="' . $prevUrl . '" />';
+    if ($linkNext) echo '<link rel="next" href="' . $nextUrl . '" />';
+}
+
+?>


### PR DESCRIPTION
For my own purposes, I wanted to add rel next and prev ref tags. The original code comes from [Inchoo](http://inchoo.net/magento/how-to-implement-relprev-and-relnext-to-magentos-pagination/) However that code didn't work with this module, or at all when filters were selected.

Also, I did not like the way Magento did canonical URLs for categories in conjunction with the rel next and prev modifications I made, so I implemented that too. See [this topic](https://support.google.com/webmasters/answer/1663744?hl=en) at Google support.

I'm still sort of new to writing Magento modules, so let me know if something doesn't look right. I suppose this could become an option in the admin config.