### PR TITLE
Remove nofollow for multiselect which is no longer an href

### DIFF
--- a/app/design/frontend/base/default/template/catalin_seo/catalog/layer/filter.phtml
+++ b/app/design/frontend/base/default/template/catalin_seo/catalog/layer/filter.phtml
@@ -1,12 +1,9 @@
-<?php
-$_nofollow = Mage::helper('catalin_seo')->getNofollow();
-?>
 <ol>
     <?php foreach ($this->getItems() as $_item): ?>
         <li>
             <?php if ($_item->getCount() > 0): ?>
                 <?php $id = $_item->getFilter()->getRequestVar() . '-' . $_item->getValue(); ?>
-                <div class="layered-nav-filter" href="<?php echo ($_item->isSelected()) ? $_item->getRemoveUrl() : $_item->getUrl() ?>" <?php echo $_nofollow; ?> >
+                <div class="layered-nav-filter" href="<?php echo ($_item->isSelected()) ? $_item->getRemoveUrl() : $_item->getUrl() ?>" >
                     <input type="checkbox"<?php if ($_item->isSelected()): ?> checked="checked" <?php endif; ?>
                            value="<?php echo ($_item->isSelected()) ? $_item->getRemoveUrl() : $_item->getUrl() ?>"
                            id="<?php echo $id; ?>" />


### PR DESCRIPTION
`nofollow` still applies to swatches but does not apply to the former `href` which is now an `input`.