### PR TITLE
Avoid a js error on empty category pages

### DIFF
--- a/app/code/community/Catalin/SEO/Model/Enterprise/Catalog/Layer/Filter/Attribute.php
+++ b/app/code/community/Catalin/SEO/Model/Enterprise/Catalog/Layer/Filter/Attribute.php
@@ -14,7 +14,7 @@
  * @copyright   Copyright (c) 2016 Catalin Ciobanu
  * @license     https://opensource.org/licenses/MIT  MIT License (MIT)
  */
-class Catalin_SEO_Model_Enterprise_Catalog_Layer_Filter_Attribute extends Mage_Catalog_Model_Catalog_Layer_Filter_Attribute
+class Catalin_SEO_Model_Enterprise_Catalog_Layer_Filter_Attribute extends Enterprise_Search_Model_Catalog_Layer_Filter_Attribute
 {
 
     protected $_values = array();

--- a/skin/frontend/base/default/js/catalin_seo/handler-ee-rwd.js
+++ b/skin/frontend/base/default/js/catalin_seo/handler-ee-rwd.js
@@ -178,7 +178,8 @@ var CatalinSeoHandler = {
             self.ajaxListener();
 
             (function (History) {
-                if (!History.enabled) {
+                // Skip empty categories.
+                if (!History.enabled || !$('catalog-listing')) {
                     return false;
                 }
 

--- a/skin/frontend/base/default/js/catalin_seo/handler-ee-rwd.js
+++ b/skin/frontend/base/default/js/catalin_seo/handler-ee-rwd.js
@@ -43,7 +43,7 @@ var CatalinSeoHandler = {
             onSuccess: function (transport) {
                 if (transport.responseJSON) {
                     $('catalog-listing').update(transport.responseJSON.listing);
-                    $$('.block-layered-nav')[0].replace(transport.responseJSON.layer);
+                    $$('.block-layered-nav')[0].update(transport.responseJSON.layer);
                     self.pushState({
                         listing: transport.responseJSON.listing,
                         layer: transport.responseJSON.layer
@@ -184,7 +184,7 @@ var CatalinSeoHandler = {
 
                 self.pushState({
                     listing: $('catalog-listing').innerHTML,
-                    layer: $$('.block-layered-nav')[0].outerHTML
+                    layer: $$('.block-layered-nav')[0].innerHTML
                 }, document.location.href, true);
 
                 // Bind to StateChange Event
@@ -192,7 +192,7 @@ var CatalinSeoHandler = {
                     if (event.type == 'popstate') {
                         var State = History.getState();
                         $('catalog-listing').update(State.data.listing);
-                        $$('.block-layered-nav')[0].replace(State.data.layer);
+                        $$('.block-layered-nav')[0].update(State.data.layer);
                         self.ajaxListener();
                         self.toggleContent();
                         self.alignProductGridActions();

--- a/skin/frontend/base/default/js/catalin_seo/handler.js
+++ b/skin/frontend/base/default/js/catalin_seo/handler.js
@@ -141,7 +141,8 @@ var CatalinSeoHandler = {
             self.ajaxListener();
 
             (function (History) {
-                if (!History.enabled) {
+                // Skip empty categories.
+                if (!History.enabled || !$('catalog-listing')) {
                     return false;
                 }
 


### PR DESCRIPTION
Please note: this also brings a change into develop that was only merged into master.

This js error doesn't cause any real problems, but it shows up in the console and can trigger error monitoring or continuous integration.  Of course, empty categories shouldn't be common, ideally.