### PR TITLE
Fix FPC-related issues

### DIFF
--- a/app/code/community/Catalin/SEO/Helper/Data.php
+++ b/app/code/community/Catalin/SEO/Helper/Data.php
@@ -47,6 +47,17 @@ class Catalin_SEO_Helper_Data extends Mage_Core_Helper_Data
     }
 
     /**
+     * Check if ajax request URI is formed properly to avoid FPC caching HTML source
+     *
+     * @param object $request
+     * @return boolean
+     */
+    public function isRequestAjax()
+    {
+        return (strpos(Mage::app()->getRequest()->getRequestString(), '/isLayerAjax/1') !== false);
+    }
+
+    /**
      * Check if multiple choice filters is enabled
      *
      * @return boolean

--- a/app/code/community/Catalin/SEO/controllers/CategoryController.php
+++ b/app/code/community/Catalin/SEO/controllers/CategoryController.php
@@ -21,6 +21,9 @@ class Catalin_Seo_CategoryController extends Mage_Catalog_CategoryController
 
     public function viewAction()
     {
+        $helper = Mage::helper('catalin_seo');
+        /* $helper Catalin_SEO_Helper_Data */
+
         if (($category = $this->_initCatagory())) {
             $design = Mage::getSingleton('catalog/design');
             $settings = $design->getDesignSettings($category);
@@ -43,7 +46,7 @@ class Catalin_Seo_CategoryController extends Mage_Catalog_CategoryController
             $update->addHandle($category->getLayoutUpdateHandle());
             $update->addHandle('CATEGORY_' . $category->getId());
             // apply custom ajax layout
-            if (Mage::helper('catalin_seo')->isAjaxEnabled() && $this->getRequest()->isAjax()) {
+            if ($helper->isAjaxEnabled() && $helper->isRequestAjax()) {
                 $update->addHandle('catalog_category_layered_ajax_layer');
             }
             $this->loadLayoutUpdates();
@@ -72,7 +75,7 @@ class Catalin_Seo_CategoryController extends Mage_Catalog_CategoryController
             $this->_initLayoutMessages('checkout/session');
 
             // return json formatted response for ajax
-            if (Mage::helper('catalin_seo')->isAjaxEnabled() && $this->getRequest()->isAjax()) {
+            if ($helper->isAjaxEnabled() && $helper->isRequestAjax()) {
                 
                 if(Mage::getEdition() == Mage::EDITION_ENTERPRISE){
                     $block = $this->getLayout()->getBlock('enterprisecatalog.leftnav');

--- a/app/code/community/Catalin/SEO/controllers/ResultController.php
+++ b/app/code/community/Catalin/SEO/controllers/ResultController.php
@@ -24,6 +24,9 @@ class Catalin_Seo_ResultController extends Mage_CatalogSearch_ResultController
      */
     public function indexAction()
     {
+        $helper = Mage::helper('catalin_seo');
+        /* $helper Catalin_SEO_Helper_Data */
+
         $query = Mage::helper('catalogsearch')->getQuery();
         /* @var $query Mage_CatalogSearch_Model_Query */
 
@@ -54,7 +57,7 @@ class Catalin_Seo_ResultController extends Mage_CatalogSearch_ResultController
 
             $this->loadLayout();
             // apply custom ajax layout
-            if (Mage::helper('catalin_seo')->isAjaxEnabled() && $this->getRequest()->isAjax()) {
+            if ($helper->isAjaxEnabled() && $helper->isRequestAjax()) {
                 $update = $this->getLayout()->getUpdate();
                 $update->addHandle('catalog_category_layered_ajax_layer');
             }
@@ -62,7 +65,7 @@ class Catalin_Seo_ResultController extends Mage_CatalogSearch_ResultController
             $this->_initLayoutMessages('checkout/session');
 
             // return json formatted response for ajax
-            if (Mage::helper('catalin_seo')->isAjaxEnabled() && $this->getRequest()->isAjax()) {
+            if ($helper->isAjaxEnabled() && $helper->isRequestAjax()) {
                 $listing = $this->getLayout()->getBlock('search_result_list')->toHtml();
 
 


### PR DESCRIPTION
There are two issues this is intended to address:

1) Avoid incorrect content-type headers from being cached in full page cache
2) Avoid incorrect response data from being cached in FPC

Worth noting that this change will likely break things on sites that utilize request URI's with an `isLayerAjax` querystring parameter.

* Conceptual credit on this goes to @toddbc.