### PR TITLE
Add possibility of composer installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,27 @@ $ modman init
 $ modman clone https://github.com/caciobanu/improved-magento-layered-navigation.git
 ```
 
+Install via Composer
+----------------
+
+You can install this module [Composer](https://getcomposer.org/) in combination with a Magento Composer installer (e.g. [Bragento Composer Installer](https://github.com/bragento/bragento-composer-installer)).
+
+Make sure you have required the [Firegento packages](https://packages.firegento.com/) in your composer.json's `repositories` node
+
+```json
+"repositories": [
+    {
+      "type": "composer",
+      "url": "https://packages.firegento.com"
+    }
+]
+```
+Afterwards you can install this module by simply requireing it.
+
+```bash
+$ composer require caciobanu/improved-magento-layered-navigation
+```
+
 Contribution
 ------------
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ modman clone https://github.com/caciobanu/improved-magento-layered-navigation.
 Install via Composer
 ----------------
 
-You can install this module [Composer](https://getcomposer.org/) in combination with a Magento Composer installer (e.g. [Bragento Composer Installer](https://github.com/bragento/bragento-composer-installer)).
+You can install this module with [Composer](https://getcomposer.org/) in combination with a Magento Composer installer (e.g. [Bragento Composer Installer](https://github.com/bragento/bragento-composer-installer)).
 
 Make sure you have required the [Firegento packages](https://packages.firegento.com/) in your composer.json's `repositories` node
 
@@ -43,7 +43,7 @@ Make sure you have required the [Firegento packages](https://packages.firegento.
     }
 ]
 ```
-Afterwards you can install this module by simply requireing it.
+Afterwards you can install this module by simply requiring it.
 
 ```bash
 $ composer require caciobanu/improved-magento-layered-navigation

--- a/modman
+++ b/modman
@@ -1,14 +1,14 @@
 # app
-app/code/community/Catalin/SEO
+app/code/community/Catalin/SEO app/code/community/Catalin/SEO
 
 # design
-app/design/frontend/base/default/layout/catalin_seo.xml
-app/design/frontend/base/default/template/catalin_seo
+app/design/frontend/base/default/layout/catalin_seo.xml app/design/frontend/base/default/layout/catalin_seo.xml
+app/design/frontend/base/default/template/catalin_seo app/design/frontend/base/default/template/catalin_seo
 
 # etc
-app/etc/modules/Catalin_SEO.xml
+app/etc/modules/Catalin_SEO.xml app/etc/modules/Catalin_SEO.xml
 
 # skin
-skin/frontend/base/default/css/catalin_seo
-skin/frontend/base/default/images/catalin_seo
-skin/frontend/base/default/js/catalin_seo
+skin/frontend/base/default/css/catalin_seo skin/frontend/base/default/css/catalin_seo
+skin/frontend/base/default/images/catalin_seo skin/frontend/base/default/images/catalin_seo
+skin/frontend/base/default/js/catalin_seo skin/frontend/base/default/js/catalin_seo


### PR DESCRIPTION
Update modman mapping to be used with composer installers as well. 
Therefore the mapping has to be done explicitly naming the source and the destination.

Further update the README introducing explanation for composer install.