### PR TITLE
Update handler.js

### DIFF
--- a/skin/frontend/base/default/js/catalin_seo/handler.js
+++ b/skin/frontend/base/default/js/catalin_seo/handler.js
@@ -61,7 +61,9 @@ var CatalinSeoHandler = {
             onSuccess: function (transport) {
                 if (transport.responseJSON) {
                     $('catalog-listing').update(transport.responseJSON.listing);
+                    if ($('layered-navigation') != null) {
                     $('layered-navigation').update(transport.responseJSON.layer);
+                    };
                     self.pushState({
                         listing: transport.responseJSON.listing,
                         layer: transport.responseJSON.layer
@@ -160,10 +162,16 @@ var CatalinSeoHandler = {
                     return false;
                 }
 
+				if ($('layered-navigation') == null) {
+                self.pushState({
+                    listing: $('catalog-listing').innerHTML
+                }, document.location.href, true);
+                } else {
                 self.pushState({
                     listing: $('catalog-listing').innerHTML,
                     layer: $('layered-navigation').innerHTML
                 }, document.location.href, true);
+                };
 
                 // Bind to StateChange Event
                 History.Adapter.bind(window, 'popstate', function (event) {


### PR DESCRIPTION
prevent error if $('layered-navigation') is not shown on a particular page (for example if on a certain category page number of columns is reduced so left column is not use.