### PR TITLE
Force disable category links on search result page

### DIFF
--- a/app/code/community/Catalin/SEO/Helper/Data.php
+++ b/app/code/community/Catalin/SEO/Helper/Data.php
@@ -74,12 +74,13 @@ class Catalin_SEO_Helper_Data extends Mage_Core_Helper_Data
 
     /**
      * Check if category links are enabled instead of the filter
+     * Everytime false when you'r not in category page (search result page for exemple)
      *
      * @return boolean
      */
     public function isCategoryLinksEnabled()
     {
-        if (!$this->isEnabled()) {
+        if (!$this->isEnabled() || !Mage::registry('current_category')) {
             return false;
         }
         return Mage::getStoreConfigFlag('catalin_seo/catalog/category_links');


### PR DESCRIPTION
I think you never need this option on result search page.
When this option is enabled, on result search page when you filter by category you have ugly URL with full URL like _`'magento.comcatalogsearch/result/index/?cat=http%3A%2F%2Fwww.magento.code%2Fcategory1&q=word'`_

I think it's maybe use when you need disable ajax on category filter on result search page, so you maybe need create new system > config for enable / disable this.